### PR TITLE
Fix loading of gateway classes as PSR-4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,9 @@
     "homepage": "https://github.com/kbahchevanov/omnipay-moneris",
     "license": "MIT",
     "autoload": {
-        "psr-0": { "Omnipay\\Moneris\\" : "src/" }
+        "psr-4": {
+            "Omnipay\\Moneris\\" : "src/",
+        }
     },
     "require": {
         "omnipay/common": "~2.0"

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "license": "MIT",
     "autoload": {
         "psr-4": {
-            "Omnipay\\Moneris\\" : "src/",
+            "Omnipay\\Moneris\\" : "src/"
         }
     },
     "require": {


### PR DESCRIPTION
The code seems to be using PSR-4 standards (e.g. `Gateway` is located in `/src/Gateway.php` instead of `/src/Omnipay/Moneris/Gateway.php`), but it is incorrectly being advertised as PSR-0, making it impossible to load. 